### PR TITLE
Use a `sansec` specific cron group

### DIFF
--- a/etc/cron_groups.xml
+++ b/etc/cron_groups.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/cron_groups.xsd">
+    <group id="sansec">
+        <schedule_generate_every>1</schedule_generate_every>
+        <schedule_ahead_for>4</schedule_ahead_for>
+        <schedule_lifetime>2</schedule_lifetime>
+        <history_cleanup_every>10</history_cleanup_every>
+        <history_success_lifetime>60</history_success_lifetime>
+        <history_failure_lifetime>600</history_failure_lifetime>
+        <use_separate_process>1</use_separate_process>
+    </group>
+</config>

--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/crontab.xsd">
-    <group id="default">
+    <group id="sansec">
         <job name="sansec_shield_sync_rules" instance="Sansec\Shield\Cron\SyncRules" method="execute">
             <schedule>*/5 * * * *</schedule>
         </job>


### PR DESCRIPTION
There is no guarantee that the `default` cron group won't be stuck behind some long running process or other job.

To prevent any delay in fetching updates it is often sensible to put custom items like this into their own group.

Full disclosure, I have not had capacity to actually run / test this code, but this is how i usually set up cron groups so fingers crossed.