### PR TITLE
filter set-cookie header

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -39,6 +39,7 @@
         <arguments>
             <argument name="filteredHeaders" xsi:type="array">
                 <item name="Cookie" xsi:type="string">Cookie</item>
+                <item name="Set-Cookie" xsi:type="string">Set-Cookie</item>
                 <item name="Authorization" xsi:type="string">Authorization</item>
             </argument>
         </arguments>


### PR DESCRIPTION
This should really never happen, as clients don't send the Set-Cookie header, but we've seen this on at least 1 incorrectly configured server configuration.