### PR TITLE
use a custom serializer with JSON_INVALID_UTF8_SUBSTITUTE

### DIFF
--- a/Model/Serializer.php
+++ b/Model/Serializer.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Sansec\Shield\Model;
+
+use Magento\Framework\Serialize\SerializerInterface;
+
+class Serializer implements SerializerInterface
+{
+    public function serialize($data)
+    {
+        $result = json_encode($data, JSON_INVALID_UTF8_SUBSTITUTE);
+        if (false === $result) {
+            throw new \InvalidArgumentException("Unable to serialize value. Error: " . json_last_error_msg());
+        }
+        return $result;
+    }
+
+    public function unserialize($string)
+    {
+        if ($string === null) {
+            throw new \InvalidArgumentException(
+                'Unable to unserialize value. Error: Parameter must be a string type, null given.'
+            );
+        }
+        $result = json_decode($string, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new \InvalidArgumentException("Unable to unserialize value. Error: " . json_last_error_msg());
+        }
+        return $result;
+    }
+}

--- a/Test/Model/SerializerTest.php
+++ b/Test/Model/SerializerTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Sansec\Shield\Test\Model;
+
+class SerializerTest extends \PHPUnit\Framework\TestCase
+{
+    public function testNoExceptionWithInvalidUtf8()
+    {
+        $serializer = new \Sansec\Shield\Model\Serializer();
+        $result = $serializer->serialize(['key' => "\xB1\x31"]);
+        $this->assertEquals(JSON_ERROR_NONE, json_last_error());
+        $this->assertIsString($result);
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -24,6 +24,16 @@
     <type name="Magento\Framework\App\FrontControllerInterface">
         <plugin name="sansec_shield" type="Sansec\Shield\Plugin\ShieldPlugin"/>
     </type>
+    <type name="Sansec\Shield\Model\Rules">
+        <arguments>
+            <argument name="serializer" xsi:type="object">Sansec\Shield\Model\Serializer</argument>
+        </arguments>
+    </type>
+    <type name="Sansec\Shield\Model\Report">
+        <arguments>
+            <argument name="serializer" xsi:type="object">Sansec\Shield\Model\Serializer</argument>
+        </arguments>
+    </type>
     <type name="Sansec\Shield\Model\IP">
         <arguments>
             <argument name="ipHeaders" xsi:type="array">


### PR DESCRIPTION
Copied from [here](https://github.com/magento/magento2/blob/2.4-develop/lib/internal/Magento/Framework/Serialize/Serializer/Json.php), just added a flag.

Avoids breaking report submissions with invalid UTF-8 sequences.