### PR TITLE
fix: match whitelist against REMOTE_ADDR only

### DIFF
--- a/Model/IP.php
+++ b/Model/IP.php
@@ -20,6 +20,12 @@ class IP
         return filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) === false;
     }
 
+    public function getRemoteAddr(): ?string
+    {
+        $remote = isset($_SERVER['REMOTE_ADDR']) ? trim((string) $_SERVER['REMOTE_ADDR']) : '';
+        return $remote === '' ? null : $remote;
+    }
+
     public function collectRequestIPs(): array
     {
         if ($this->requestIPs === null) {

--- a/Plugin/Shield.php
+++ b/Plugin/Shield.php
@@ -54,12 +54,11 @@ class Shield
         if (empty($whitelisted)) {
             return false;
         }
-        foreach ($this->ip->collectRequestIPs() as $ip) {
-            if (in_array($ip, $whitelisted, true)) {
-                return true;
-            }
+        $remoteAddr = $this->ip->getRemoteAddr();
+        if ($remoteAddr === null) {
+            return false;
         }
-        return false;
+        return in_array($remoteAddr, $whitelisted, true);
     }
 
     private function getAccessDeniedResponse(): ResponseInterface

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ bin/magento sansec:shield:sync-rules
 
 You can configure your license key and other settings via System → Configuration → Security → Sansec Shield.
 
+### Whitelisted IP addresses
+
+IPs listed under *Whitelisted IP Addresses* bypass all Shield checks. Matching is performed against the connecting peer (`REMOTE_ADDR`) only; proxy-forwarded headers such as `X-Forwarded-For` and `CF-Connecting-IP` are intentionally ignored because they are client-controlled and can be spoofed.
+
+If your store sits behind a reverse proxy or CDN, configure your webserver to rewrite the trusted proxy header into `REMOTE_ADDR` ([`ngx_http_realip_module`](https://nginx.org/en/docs/http/ngx_http_realip_module.html) on nginx, [`mod_remoteip`](https://httpd.apache.org/docs/2.4/mod/mod_remoteip.html) on Apache). Once `REMOTE_ADDR` reflects the real client IP, the whitelist will match it correctly.
+
 ## Testing & live reports
 
 Test it by visiting your store and add `?SANSEC-SHIELD-TEST` to your URL, it should give you "permission denied". You'll see your first blocked attack appear instantly on your [Shield Dashboard](https://dashboard.sansec.io/d/account/shield). If you do not want reports, you can disable it with:

--- a/Test/Model/IPTest.php
+++ b/Test/Model/IPTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Sansec\Shield\Test\Model;
+
+use PHPUnit\Framework\TestCase;
+use Sansec\Shield\Model\IP;
+
+class IPTest extends TestCase
+{
+    /** @var array */
+    private $serverBackup;
+
+    protected function setUp(): void
+    {
+        $this->serverBackup = $_SERVER;
+    }
+
+    protected function tearDown(): void
+    {
+        $_SERVER = $this->serverBackup;
+    }
+
+    public function testGetRemoteAddrReturnsRemoteAddr()
+    {
+        $_SERVER['REMOTE_ADDR'] = '203.0.113.42';
+        $this->assertSame('203.0.113.42', (new IP())->getRemoteAddr());
+    }
+
+    public function testGetRemoteAddrIgnoresForwardedHeaders()
+    {
+        unset($_SERVER['REMOTE_ADDR']);
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '203.0.113.42';
+        $_SERVER['HTTP_CF_CONNECTING_IP'] = '203.0.113.42';
+        $this->assertNull((new IP())->getRemoteAddr());
+    }
+
+    public function testGetRemoteAddrReturnsNullWhenBlank()
+    {
+        $_SERVER['REMOTE_ADDR'] = "  \t";
+        $this->assertNull((new IP())->getRemoteAddr());
+    }
+}

--- a/Test/Plugin/ShieldTest.php
+++ b/Test/Plugin/ShieldTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Magento\Framework\App\Response {
+    if (!class_exists(HttpFactory::class, false)) {
+        class HttpFactory
+        {
+            public function create()
+            {
+            }
+        }
+    }
+}
+
+namespace Magento\Framework\View\Element {
+    if (!class_exists(TemplateFactory::class, false)) {
+        class TemplateFactory
+        {
+            public function create()
+            {
+            }
+        }
+    }
+}
+
+namespace Sansec\Shield\Test\Plugin {
+
+    use Magento\Framework\App\FrontControllerInterface;
+    use Magento\Framework\App\Response\HttpFactory as HttpResponseFactory;
+    use Magento\Framework\View\Element\TemplateFactory;
+    use PHPUnit\Framework\MockObject\Rule\InvocationOrder;
+    use PHPUnit\Framework\TestCase;
+    use Sansec\Shield\Model\Config;
+    use Sansec\Shield\Model\IP;
+    use Sansec\Shield\Model\Report;
+    use Sansec\Shield\Model\Waf;
+    use Sansec\Shield\Plugin\Shield;
+    use Sansec\Shield\Test\RequestStub;
+
+    class ShieldTest extends TestCase
+    {
+        /** @var array */
+        private $serverBackup;
+
+        protected function setUp(): void
+        {
+            $this->serverBackup = $_SERVER;
+        }
+
+        protected function tearDown(): void
+        {
+            $_SERVER = $this->serverBackup;
+        }
+
+        private function buildPlugin(array $whitelistedIps, InvocationOrder $expectedWafCalls): Shield
+        {
+            $config = $this->createMock(Config::class);
+            $config->method('isEnabled')->willReturn(true);
+            $config->method('getWhitelistedIps')->willReturn($whitelistedIps);
+
+            $waf = $this->createMock(Waf::class);
+            $waf->expects($expectedWafCalls)->method('matchRequest')->willReturn([]);
+
+            return new Shield(
+                $config,
+                $waf,
+                $this->createMock(Report::class),
+                new IP(),
+                $this->createMock(HttpResponseFactory::class),
+                $this->createMock(TemplateFactory::class)
+            );
+        }
+
+        private function dispatch(Shield $plugin): bool
+        {
+            $proceedCalled = false;
+            $plugin->aroundDispatch(
+                $this->createMock(FrontControllerInterface::class),
+                function () use (&$proceedCalled) {
+                    $proceedCalled = true;
+                },
+                new RequestStub()
+            );
+            return $proceedCalled;
+        }
+
+        public function testRemoteAddrInWhitelistBypassesWaf()
+        {
+            $_SERVER['REMOTE_ADDR'] = '203.0.113.42';
+            $plugin = $this->buildPlugin(['203.0.113.42'], $this->never());
+            $this->assertTrue($this->dispatch($plugin));
+        }
+
+        public function testForwardedHeaderInWhitelistDoesNotBypassWaf()
+        {
+            $_SERVER['REMOTE_ADDR'] = '198.51.100.1';
+            $_SERVER['HTTP_X_FORWARDED_FOR'] = '203.0.113.42';
+            $_SERVER['HTTP_CF_CONNECTING_IP'] = '203.0.113.42';
+            $plugin = $this->buildPlugin(['203.0.113.42'], $this->once());
+            $this->dispatch($plugin);
+        }
+
+        public function testEmptyWhitelistDoesNotBypassWaf()
+        {
+            $_SERVER['REMOTE_ADDR'] = '203.0.113.42';
+            $plugin = $this->buildPlugin([], $this->once());
+            $this->dispatch($plugin);
+        }
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -22,7 +22,7 @@
                 </field>
                 <field id="whitelisted_ips" translate="label comment" type="textarea" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Whitelisted IP Addresses</label>
-                    <comment>One IP address per line. Requests from these IPs bypass Shield checks. Ensure client IP headers are correctly set by your proxy/webserver.</comment>
+                    <comment>One IP address per line. Requests from these IPs bypass Shield checks. Matches the connecting peer only (REMOTE_ADDR); proxy-forwarded headers are intentionally ignored.</comment>
                 </field>
             </group>
         </section>


### PR DESCRIPTION
## Summary
- Restrict the IP whitelist check to `REMOTE_ADDR`, which is set by the TCP layer and cannot be spoofed by the client.
- Previously `isRequestWhitelisted()` iterated every collected IP (including `X-Forwarded-For`, `CF-Connecting-IP`, `X-Real-IP`, `Client-IP`), so an attacker could spoof any of those headers with a whitelisted IP and bypass the WAF entirely.
- Adds `IP::getRemoteAddr()`, an admin help comment update, README guidance, and unit + plugin-level tests covering both the legitimate match and the spoofing-attempt regression.

## Behavior change (please call out in release notes)
Operators behind a reverse proxy or CDN must ensure their webserver rewrites the trusted proxy header into `REMOTE_ADDR` — `ngx_http_realip_module` on nginx, `mod_remoteip` on Apache — so the whitelist matches the real client IP. Previously a whitelisted forwarded header value would (insecurely) match.

## Test plan
- [x] `SANSEC_SHIELD_RULES_PATH=Test/fixture/testrules.json vendor/bin/phpunit Test/` — 52 tests, 54 assertions, all green
- [x] `Test/Model/IPTest.php` covers `getRemoteAddr()` happy path, missing-but-XFF-present, and blank
- [x] `Test/Plugin/ShieldTest.php` covers REMOTE_ADDR bypass, XFF-only no-bypass, and empty-whitelist no-bypass
- [x] Manual smoke test on a staging store behind a proxy to confirm `mod_remoteip` / realip rewrite is in place before relying on the whitelist