### PR TITLE
Log a warning when a regex condition hits a PCRE error

### DIFF
--- a/Model/Rule.php
+++ b/Model/Rule.php
@@ -121,7 +121,11 @@ class Rule
 
         switch ($condition->type) {
             case 'regex':
-                return (bool)preg_match('/' . str_replace('/', '\/', $condition->value) . '/', $value);
+                $result = preg_match('/' . str_replace('/', '\/', $condition->value) . '/', $value);
+                if ($result === false) {
+                    $this->logPcreFailure($condition);
+                }
+                return (bool)$result;
             case 'contains':
                 return strpos($value, $condition->value) !== false;
             case 'equals':
@@ -129,6 +133,15 @@ class Rule
             default:
                 return false;
         }
+    }
+
+    private function logPcreFailure(Condition $condition): void
+    {
+        $this->logger->warning('Regex condition failed with a PCRE error.', [
+            'error' => function_exists('preg_last_error_msg') ? preg_last_error_msg() : preg_last_error(),
+            'target' => $condition->target,
+            'pattern' => $condition->value
+        ]);
     }
 
     private function targetValueMatchesCondition($value, Condition $condition): bool

--- a/Test/Model/RuleTest.php
+++ b/Test/Model/RuleTest.php
@@ -146,6 +146,27 @@ class RuleTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($rule->matches($request));
     }
 
+    public function testRuleRegexLogsAndFailsOpenOnPcreError()
+    {
+        $originalBacktrackLimit = ini_get('pcre.backtrack_limit');
+        ini_set('pcre.backtrack_limit', '1');
+
+        try {
+            $logger = $this->createMock(Logger::class);
+            $logger->expects($this->once())->method('warning');
+            $request = $this->createConfiguredMock(Http::class, [
+                'getContent' => str_repeat('a', 50) . 'X'
+            ]);
+            $rule = new Rule(new IP(), $logger, 'block', [
+                new Condition('req.body', 'regex', '(a+)+$')
+            ]);
+
+            $this->assertFalse($rule->matches($request));
+        } finally {
+            ini_set('pcre.backtrack_limit', $originalBacktrackLimit);
+        }
+    }
+
     public function testRuleWithoutConditions()
     {
         $rule = new Rule(new IP(), $this->createMock(Logger::class), 'block', []);


### PR DESCRIPTION
## Problem

In `Model/Rule.php::scalarValueMatchesCondition()`, the `regex` branch is:

```php
return (bool)preg_match('/' . str_replace('/', '\/', $condition->value) . '/', $value);
```

`preg_match()` can return `false` on a PCRE error (invalid pattern, `pcre.backtrack_limit` / JIT stack exhaustion on a large request body, invalid UTF-8 with `/u`). Casting `false` to `bool` makes it indistinguishable from a genuine non-match: the rule fails open silently and nothing is logged, so a rule that stops matching due to a PCRE error is invisible in `var/log/sansec_shield.log`.

## Change

- Added a private `logPcreFailure()` helper. It is called only when `preg_match()` returns `false`, and logs through the existing injected logger with `preg_last_error_msg()` (PHP >= 8.0) falling back to the integer `preg_last_error()` code on PHP 7.2/7.3, plus the condition's target and pattern.
- The happy path (a normal match/no-match result) is unchanged: still a single `preg_match()` call, one extra `=== false` comparison, zero extra work when the pattern evaluates normally. No new object allocation, no try/catch, no extra function calls unless PCRE actually failed.
- Fail-open behavior is preserved as-is (documented module behaviour) — the method still returns `false` on a PCRE error, only now it also logs.

## Testing

Added `testRuleRegexLogsAndFailsOpenOnPcreError()` in `Test/Model/RuleTest.php`.

It triggers a genuine runtime PCRE failure rather than a pattern compile error: `ini_set('pcre.backtrack_limit', '1')` plus a catastrophic-backtracking pattern (`(a+)+$`) against a non-matching body forces `preg_match()` to return `false` via `PREG_BACKTRACK_LIMIT_ERROR` (or the JIT-stack equivalent). This path does not emit a PHP `E_WARNING`, unlike an invalid pattern (unbalanced parenthesis etc.), which would raise "`preg_match(): Compilation failed`" and fail PHPUnit's `--fail-on-warning` run. The test asserts `Rule::matches()` still returns `false` (fail-open) and that the logger mock receives exactly one `warning()` call, then restores the original `pcre.backtrack_limit` in a `finally` block.

Local test run: PHPUnit with `--fail-on-warning` and `xmllint` on `etc/*.xml` passed (58 tests, 64 assertions).


