### PR TITLE
Send attack reports after the response is flushed

### DIFF
--- a/Model/Report.php
+++ b/Model/Report.php
@@ -95,14 +95,14 @@ class Report
             'version' => $this->getPackageVersion(),
             'product_version' => $this->getProductVersion(),
             'request' => [
-                'method'  => $request->getMethod(),
-                'uri'     => $request->getRequestUri(),
-                'body'    => $request->getContent(),
-                'ips'     => $this->ip->collectRequestIPs(),
+                'method' => $request->getMethod(),
+                'uri' => $request->getRequestUri(),
+                'body' => $request->getContent(),
+                'ips' => $this->ip->collectRequestIPs(),
                 'headers' => $this->getRequestHeaders($request),
-                'scheme'  => $request->getScheme(),
-                'params'  => $request->getParams(),
-                'files'   => $request->getFiles(),
+                'scheme' => $request->getScheme(),
+                'params' => $request->getParams(),
+                'files' => $request->getFiles(),
             ]
         ]);
     }

--- a/Model/Report.php
+++ b/Model/Report.php
@@ -31,6 +31,12 @@ class Report
     /** @var string[] */
     private $filteredHeaders;
 
+    /** @var string[] */
+    private $pendingPayloads = [];
+
+    /** @var bool */
+    private $shutdownRegistered = false;
+
     public function __construct(
         Config $config,
         CurlFactory $curlFactory,
@@ -80,41 +86,94 @@ class Report
         );
     }
 
+    private function buildPayload(RequestInterface $request, array $rules): string
+    {
+        return $this->serializer->serialize([
+            'type' => 'report',
+            'timestamp' => time(),
+            'rules' => $rules,
+            'version' => $this->getPackageVersion(),
+            'product_version' => $this->getProductVersion(),
+            'request' => [
+                'method'  => $request->getMethod(),
+                'uri'     => $request->getRequestUri(),
+                'body'    => $request->getContent(),
+                'ips'     => $this->ip->collectRequestIPs(),
+                'headers' => $this->getRequestHeaders($request),
+                'scheme'  => $request->getScheme(),
+                'params'  => $request->getParams(),
+                'files'   => $request->getFiles(),
+            ]
+        ]);
+    }
+
+    private function postPayload(string $data)
+    {
+        $curl = $this->curlFactory->create();
+        $curl->setCredentials($this->config->getLicenseKey(), $this->config->getLicenseKey());
+        $curl->setTimeout(5);
+        $curl->addHeader('Expect', ''); // prevents curl from expecting 100-continue
+        $curl->addHeader('Content-Type', 'application/json');
+        $curl->post($this->config->getReportUrl(), $data);
+
+        if (!in_array($curl->getStatus(), [200, 429])) {
+            throw new \RuntimeException(sprintf("Invalid status code: %d", $curl->getStatus()));
+        }
+    }
+
+    private function logFailure(\Exception $e)
+    {
+        $this->logger->error(sprintf("Failed to send report: %s", $e->getMessage()));
+    }
+
     public function sendReport(RequestInterface $request, array $rules)
     {
         if (!$this->config->isReportEnabled()) {
             return;
         }
         try {
-            $curl = $this->curlFactory->create();
-            $curl->setCredentials($this->config->getLicenseKey(), $this->config->getLicenseKey());
-            $curl->setTimeout(5);
-            $curl->addHeader('Expect', ''); // prevents curl from expecting 100-continue
-            $curl->addHeader('Content-Type', 'application/json');
-            $data = $this->serializer->serialize([
-                'type' => 'report',
-                'timestamp' => time(),
-                'rules' => $rules,
-                'version' => $this->getPackageVersion(),
-                'product_version' => $this->getProductVersion(),
-                'request' => [
-                    'method'  => $request->getMethod(),
-                    'uri'     => $request->getRequestUri(),
-                    'body'    => $request->getContent(),
-                    'ips'     => $this->ip->collectRequestIPs(),
-                    'headers' => $this->getRequestHeaders($request),
-                    'scheme'  => $request->getScheme(),
-                    'params'  => $request->getParams(),
-                    'files'   => $request->getFiles(),
-                ]
-            ]);
-            $curl->post($this->config->getReportUrl(), $data);
-
-            if (!in_array($curl->getStatus(), [200, 429])) {
-                throw new \RuntimeException(sprintf("Invalid status code: %d", $curl->getStatus()));
-            }
+            $this->postPayload($this->buildPayload($request, $rules));
         } catch (\Exception $e) {
-            $this->logger->error(sprintf("Failed to send report: %s", $e->getMessage()));
+            $this->logFailure($e);
+        }
+    }
+
+    public function sendReportDeferred(RequestInterface $request, array $rules)
+    {
+        if (!$this->config->isReportEnabled()) {
+            return;
+        }
+        try {
+            // Built now: at shutdown the request body stream, the config cache and the version cache
+            // backend may already be closed.
+            $this->pendingPayloads[] = $this->buildPayload($request, $rules);
+        } catch (\Exception $e) {
+            $this->logFailure($e);
+            return;
+        }
+        if (!$this->shutdownRegistered) {
+            $this->shutdownRegistered = true;
+            register_shutdown_function([$this, 'flushDeferredReports']);
+        }
+    }
+
+    public function flushDeferredReports()
+    {
+        $payloads = $this->pendingPayloads;
+        $this->pendingPayloads = [];
+        if (empty($payloads)) {
+            return;
+        }
+        // Only PHP-FPM exposes this; on CLI and mod_php the reports are sent as before.
+        if (function_exists('fastcgi_finish_request')) {
+            fastcgi_finish_request();
+        }
+        foreach ($payloads as $payload) {
+            try {
+                $this->postPayload($payload);
+            } catch (\Exception $e) {
+                $this->logFailure($e);
+            }
         }
     }
 

--- a/Plugin/Shield.php
+++ b/Plugin/Shield.php
@@ -86,7 +86,7 @@ class Shield
             return $proceed($request);
         }
 
-        $this->report->sendReport($request, $matchedRules);
+        $this->report->sendReportDeferred($request, $matchedRules);
 
         foreach ($matchedRules as $rule) {
             if ($rule->action === 'block') {

--- a/Test/Model/ReportTest.php
+++ b/Test/Model/ReportTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Sansec\Shield\Test\Model;
+
+use Magento\Framework\App\ProductMetadataInterface;
+use Magento\Framework\HTTP\Client\Curl;
+use Magento\Framework\HTTP\Client\CurlFactory;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface as Logger;
+use Sansec\Shield\Model\Config;
+use Sansec\Shield\Model\IP;
+use Sansec\Shield\Model\Report;
+use Sansec\Shield\Model\Serializer;
+use Sansec\Shield\Test\RequestStub;
+
+class ReportTest extends TestCase
+{
+    /** @var array[] */
+    private $posts = [];
+
+    private function buildReport(bool $reportEnabled = true): Report
+    {
+        $config = $this->createMock(Config::class);
+        $config->method('isReportEnabled')->willReturn($reportEnabled);
+        $config->method('getLicenseKey')->willReturn('key');
+        $config->method('getReportUrl')->willReturn('https://shield.example.com/report');
+
+        $curl = $this->createMock(Curl::class);
+        $curl->method('getStatus')->willReturn(200);
+        $curl->method('post')->willReturnCallback(function ($url, $data) {
+            $this->posts[] = [$url, $data];
+        });
+
+        $curlFactory = $this->getMockBuilder(CurlFactory::class)
+            ->disableOriginalConstructor()
+            ->disableAutoload()
+            ->setMethods(['create'])
+            ->getMock();
+        $curlFactory->method('create')->willReturn($curl);
+
+        return new Report(
+            $config,
+            $curlFactory,
+            $this->createMock(Logger::class),
+            new Serializer(),
+            new IP(),
+            $this->createMock(ProductMetadataInterface::class)
+        );
+    }
+
+    public function testDeferredReportIsNotPostedImmediately()
+    {
+        $report = $this->buildReport();
+        $report->sendReportDeferred(new RequestStub(), []);
+
+        $this->assertSame([], $this->posts);
+
+        $report->flushDeferredReports();
+        $this->assertCount(1, $this->posts);
+    }
+
+    public function testFlushPostsEveryDeferredReport()
+    {
+        $report = $this->buildReport();
+        $report->sendReportDeferred(new RequestStub('', 'POST', '/first'), []);
+        $report->sendReportDeferred(new RequestStub('', 'POST', '/second'), []);
+        $report->flushDeferredReports();
+
+        $this->assertCount(2, $this->posts);
+        $this->assertSame('https://shield.example.com/report', $this->posts[0][0]);
+        $this->assertStringContainsString('"uri":"\/first"', $this->posts[0][1]);
+        $this->assertStringContainsString('"uri":"\/second"', $this->posts[1][1]);
+        $this->assertStringContainsString('"type":"report"', $this->posts[0][1]);
+    }
+
+    public function testFlushIsIdempotent()
+    {
+        $report = $this->buildReport();
+        $report->sendReportDeferred(new RequestStub(), []);
+        $report->flushDeferredReports();
+        $report->flushDeferredReports();
+
+        $this->assertCount(1, $this->posts);
+    }
+
+    public function testNothingIsQueuedWhenReportingDisabled()
+    {
+        $report = $this->buildReport(false);
+        $report->sendReportDeferred(new RequestStub(), []);
+        $report->flushDeferredReports();
+
+        $this->assertSame([], $this->posts);
+    }
+}

--- a/Test/Plugin/ShieldTest.php
+++ b/Test/Plugin/ShieldTest.php
@@ -25,13 +25,17 @@ namespace Magento\Framework\View\Element {
 namespace Sansec\Shield\Test\Plugin {
 
     use Magento\Framework\App\FrontControllerInterface;
+    use Magento\Framework\App\Response\Http as HttpResponse;
     use Magento\Framework\App\Response\HttpFactory as HttpResponseFactory;
+    use Magento\Framework\View\Element\Template;
     use Magento\Framework\View\Element\TemplateFactory;
     use PHPUnit\Framework\MockObject\Rule\InvocationOrder;
     use PHPUnit\Framework\TestCase;
+    use Psr\Log\LoggerInterface as Logger;
     use Sansec\Shield\Model\Config;
     use Sansec\Shield\Model\IP;
     use Sansec\Shield\Model\Report;
+    use Sansec\Shield\Model\Rule;
     use Sansec\Shield\Model\Waf;
     use Sansec\Shield\Plugin\Shield;
     use Sansec\Shield\Test\RequestStub;
@@ -51,23 +55,45 @@ namespace Sansec\Shield\Test\Plugin {
             $_SERVER = $this->serverBackup;
         }
 
-        private function buildPlugin(array $whitelistedIps, InvocationOrder $expectedWafCalls): Shield
-        {
+        private function buildPlugin(
+            array $whitelistedIps,
+            InvocationOrder $expectedWafCalls,
+            array $matchedRules = [],
+            ?Report $report = null
+        ): Shield {
             $config = $this->createMock(Config::class);
             $config->method('isEnabled')->willReturn(true);
             $config->method('getWhitelistedIps')->willReturn($whitelistedIps);
 
             $waf = $this->createMock(Waf::class);
-            $waf->expects($expectedWafCalls)->method('matchRequest')->willReturn([]);
+            $waf->expects($expectedWafCalls)->method('matchRequest')->willReturn($matchedRules);
 
             return new Shield(
                 $config,
                 $waf,
-                $this->createMock(Report::class),
+                $report ?: $this->createMock(Report::class),
                 new IP(),
-                $this->createMock(HttpResponseFactory::class),
-                $this->createMock(TemplateFactory::class)
+                $this->buildResponseFactory(),
+                $this->buildTemplateFactory()
             );
+        }
+
+        private function buildResponseFactory(): HttpResponseFactory
+        {
+            $factory = $this->createMock(HttpResponseFactory::class);
+            $factory->method('create')->willReturn($this->createMock(HttpResponse::class));
+            return $factory;
+        }
+
+        private function buildTemplateFactory(): TemplateFactory
+        {
+            $template = $this->createMock(Template::class);
+            $template->method('setTemplate')->willReturnSelf();
+            $template->method('toHtml')->willReturn('');
+
+            $factory = $this->createMock(TemplateFactory::class);
+            $factory->method('create')->willReturn($template);
+            return $factory;
         }
 
         private function dispatch(Shield $plugin): bool
@@ -104,6 +130,36 @@ namespace Sansec\Shield\Test\Plugin {
             $_SERVER['REMOTE_ADDR'] = '203.0.113.42';
             $plugin = $this->buildPlugin([], $this->once());
             $this->dispatch($plugin);
+        }
+
+        public function testMatchedRuleDefersTheReport()
+        {
+            $_SERVER['REMOTE_ADDR'] = '203.0.113.42';
+
+            $rule = new Rule(new IP(), $this->createMock(Logger::class), 'report');
+            $report = $this->createMock(Report::class);
+            $report->expects($this->never())->method('sendReport');
+            $report->expects($this->once())->method('sendReportDeferred')->with(
+                $this->isInstanceOf(RequestStub::class),
+                [$rule]
+            );
+
+            $plugin = $this->buildPlugin([], $this->once(), [$rule], $report);
+            $this->assertTrue($this->dispatch($plugin));
+        }
+
+        public function testBlockingRuleDefersTheReportAndSkipsDispatch()
+        {
+            $_SERVER['REMOTE_ADDR'] = '203.0.113.42';
+
+            $rule = new Rule(new IP(), $this->createMock(Logger::class), 'block');
+            $report = $this->createMock(Report::class);
+            $report->expects($this->never())->method('sendReport');
+            $report->expects($this->once())->method('sendReportDeferred');
+            $report->expects($this->once())->method('logBlockedRequest');
+
+            $plugin = $this->buildPlugin([], $this->once(), [$rule], $report);
+            $this->assertFalse($this->dispatch($plugin));
         }
     }
 }

--- a/Test/RequestStub.php
+++ b/Test/RequestStub.php
@@ -112,4 +112,19 @@ class RequestStub implements RequestInterface
     {
         return $this->post;
     }
+
+    public function getHeaders()
+    {
+        return new \Laminas\Stdlib\Parameters($this->headers);
+    }
+
+    public function getFiles()
+    {
+        return new \Laminas\Stdlib\Parameters([]);
+    }
+
+    public function getScheme()
+    {
+        return 'https';
+    }
 }


### PR DESCRIPTION
## Problem

`Plugin\Shield::aroundDispatch` calls `Report::sendReport()` as soon as `Waf::matchRequest()` returns anything, before the block decision, and for `report`-action rules too. `sendReport()` is a blocking curl POST to `shield.sansec.io` with `setTimeout(5)`.

The client therefore waits for that POST on every matched request:

* healthy endpoint: response time grows by one round trip, 30–150 ms;
* slow or unreachable endpoint: up to the full 5 s timeout, on top of a request whose own work was already finished.

The worker-pool cost is worse than the latency. A worker is occupied for the whole POST, so with a pool of 50 workers and a 5 s timeout the site can absorb `50 / 5 = 10` matched requests per second before every worker is sitting in curl. A trivial flood of requests that hit a WAF rule (exactly the traffic the module exists to catch) saturates the pool, and legitimate traffic queues behind it. The blocked attacker pays nothing; the shop pays.

## Design

`Report` gains two public methods and keeps `sendReport()` untouched for any third-party caller:

* `sendReportDeferred(RequestInterface $request, array $rules)` — builds the JSON payload right away, pushes it onto an in-process queue, and registers `flushDeferredReports` with `register_shutdown_function()` the first time it is called. A `$shutdownRegistered` flag keeps the registration to one per process even if several requests match in a single worker lifetime, and the queue means several matches within one request all get reported.
* `flushDeferredReports()` — drains the queue, calls `fastcgi_finish_request()` when that function exists, and posts each payload. It empties the queue before posting, so a second call is a no-op.

`Plugin\Shield` changes by one line: `sendReport` becomes `sendReportDeferred`. The block decision and the 403 response are untouched.

Ordering in `Bootstrap::run()` is what makes this work: `$application->launch()` runs the front controller (and this plugin), and only then `$response->sendResponse()` echoes the headers and body. Shutdown functions run after the script body, i.e. after `sendResponse()`. Under PHP-FPM `fastcgi_finish_request()` closes the connection to the web server at that point, so the client is served while the worker still holds the POST.

Notes on the edge cases:

* **Payload is built eagerly, not at shutdown.** This is the one place the obvious implementation would have been wrong. `sendReport()` reads `$request->getContent()` and calls `ProductMetadataInterface::getVersion()`, which in `Magento\Framework\App\ProductMetadata` goes through `CacheInterface` (`mage-version`) and, on a miss, through `ComposerInformation`. At shutdown the cache backend connection (Redis, DB) may already be gone, and the request body stream is not guaranteed readable after `fastcgi_finish_request()`. Serialising in `sendReportDeferred()` (while the application stack is still fully up) removes that whole class of failure and guarantees a byte-identical payload. The only observable difference is that `timestamp` is now the moment of the match rather than the moment of the POST, which is arguably more correct.
* **A shutdown function still runs when later code throws.** If a controller or another plugin blows up after the match, the report is still sent. Today it would also be sent, because the POST happened before the throw; behaviour is preserved and the report survives fatal errors too.
* **`exit` paths:** Magento does not `exit` on the normal flow, and `register_shutdown_function` callbacks run on `exit()` as well, so an early exit somewhere else does not lose the report.
* **CLI and mod_php.** `fastcgi_finish_request()` does not exist there, so the call is skipped and the POST simply happens at shutdown instead of mid-dispatch, no worse than today.
* **Memory:** the request object was alive until shutdown anyway; the queue holds serialised JSON strings, which is less than holding the request.

## What does not change

* **The payload:** same keys, same values, same filtered headers (`Cookie`, `Set-Cookie`, `Authorization`), same serializer. The POST body is byte-identical apart from `timestamp`, which now marks the match.
* **The timeout:** still `setTimeout(5)`. Because the client is no longer waiting, that 5 s now bounds only how long a worker can be occupied after the response has been flushed. It no longer bounds the user's page load.
* **Dashboard immediacy:** the POST still happens inside the same request lifecycle, milliseconds after the response is flushed. No cron, no consumer, no polling interval. Reports for both `block` and `report` actions are still sent, and the blocked response is still 403 with the `access_denied.phtml` template.
* **Dependencies:** still `magento/framework` only.

## Rejected alternatives

* **AMQP / `magento/framework-message-queue`:** adds a dependency the module does not have, requires operators to run a consumer (and to notice when it dies), delays the dashboard by the consumer's poll interval, and, with the DB queue fallback, parks full request bodies, headers and IPs in `queue_message` rows. That is attack payloads and PII at rest in the merchant's database for as long as the queue is not drained. Wrong trade for a module whose value is that it is small.
* **Fire-and-forget curl with a sub-second timeout:** cheap to write, but it turns every report into a coin flip: any endpoint slower than the timeout silently loses the report, and slow endpoints are exactly the case this PR is about. Deferral keeps delivery reliable and moves the cost off the critical path instead of trading correctness for it.
* **Registering the shutdown function in the plugin:** keeps `Report` simple but scatters lifecycle handling into the plugin and makes the queueing untestable. The plugin stays a one-line call.

## Testing

Unit tests (`vendor/bin/phpunit Test`, 63 tests green):

* `Test/Model/ReportTest.php` — new. Covers that `sendReportDeferred()` posts nothing at call time; that `flushDeferredReports()` then posts one payload per deferred report, to the configured URL, with the expected JSON; that a second flush is a no-op; and that nothing is queued or posted when `report_enabled` is off. `flushDeferredReports()` is public precisely so the flush can be driven directly. `register_shutdown_function` cannot be fired from a test.
* `Test/Plugin/ShieldTest.php` — two new cases: a matched `report` rule calls `sendReportDeferred()` once and `sendReport()` never while dispatch still proceeds; a matched `block` rule defers the report, logs the block, and returns the 403 instead of dispatching.
* `Test/RequestStub.php` gained `getHeaders()`, `getFiles()` and `getScheme()`, which `Report` needs to build a payload.

Manual scenario. The response must not wait for a dead endpoint:

1. Point the module at a listener that accepts the connection and never answers:

   ```
   nc -l 9999
   bin/magento config:set sansec_shield/general/report_url http://127.0.0.1:9999/report
   bin/magento config:set sansec_shield/general/report_enabled 1
   bin/magento cache:flush
   ```

2. Trigger the built-in test rule and measure:

   ```
   curl -s -o /dev/null -w 'status=%{http_code} total=%{time_total}\n' \
     'https://example.test/?SANSEC-SHIELD-TEST'
   ```

3. Before this change: `total` is ~5.0 s. The 403 body arrives only after curl inside the worker gives up. After this change: `status=403` with `total` in the low tens of milliseconds. The `nc` listener still shows the connection opening, and `top`/`fpm status` shows the worker busy for a further 5 s, which is the timeout now bounding worker occupancy rather than page load.

4. Re-point `report_url` at the real endpoint and confirm the attack shows up in the dashboard immediately, and that `var/log/sansec_shield.log` records the block as before.

