### PR TITLE
Optional message queue transport for attack reports

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -6,11 +6,15 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
 
 class Config
 {
+    public const REPORT_TRANSPORT_DIRECT = 'direct';
+    public const REPORT_TRANSPORT_QUEUE = 'queue';
+
     private const XML_PATH_ENABLED = 'sansec_shield/general/enabled';
     private const XML_PATH_LICENSE_KEY = 'sansec_shield/general/license_key';
     private const XML_PATH_RULES_URL = 'sansec_shield/general/rules_url';
     private const XML_PATH_REPORT_ENABLED = 'sansec_shield/general/report_enabled';
     private const XML_PATH_REPORT_URL = 'sansec_shield/general/report_url';
+    private const XML_PATH_REPORT_TRANSPORT = 'sansec_shield/general/report_transport';
     private const XML_PATH_WHITELISTED_IPS = 'sansec_shield/general/whitelisted_ips';
 
     /** @var ScopeConfigInterface */
@@ -45,6 +49,11 @@ class Config
     public function getReportUrl(): string
     {
         return $this->config->getValue(self::XML_PATH_REPORT_URL);
+    }
+
+    public function getReportTransport(): string
+    {
+        return (string) ($this->config->getValue(self::XML_PATH_REPORT_TRANSPORT) ?: self::REPORT_TRANSPORT_DIRECT);
     }
 
     /** @return string[] */

--- a/Model/Config/Source/ReportTransport.php
+++ b/Model/Config/Source/ReportTransport.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Sansec\Shield\Model\Config\Source;
+
+use Magento\Framework\Data\OptionSourceInterface;
+use Sansec\Shield\Model\Config;
+
+class ReportTransport implements OptionSourceInterface
+{
+    public function toOptionArray(): array
+    {
+        return [
+            ['value' => Config::REPORT_TRANSPORT_DIRECT, 'label' => __('Direct HTTP POST')],
+            ['value' => Config::REPORT_TRANSPORT_QUEUE, 'label' => __('Message Queue')]
+        ];
+    }
+}

--- a/Model/Report.php
+++ b/Model/Report.php
@@ -95,14 +95,14 @@ class Report
             'version' => $this->getPackageVersion(),
             'product_version' => $this->getProductVersion(),
             'request' => [
-                'method'  => $request->getMethod(),
-                'uri'     => $request->getRequestUri(),
-                'body'    => $request->getContent(),
-                'ips'     => $this->ip->collectRequestIPs(),
+                'method' => $request->getMethod(),
+                'uri' => $request->getRequestUri(),
+                'body' => $request->getContent(),
+                'ips' => $this->ip->collectRequestIPs(),
                 'headers' => $this->getRequestHeaders($request),
-                'scheme'  => $request->getScheme(),
-                'params'  => $request->getParams(),
-                'files'   => $request->getFiles(),
+                'scheme' => $request->getScheme(),
+                'params' => $request->getParams(),
+                'files' => $request->getFiles(),
             ]
         ]);
     }

--- a/Model/Report.php
+++ b/Model/Report.php
@@ -31,6 +31,12 @@ class Report
     /** @var string[] */
     private $filteredHeaders;
 
+    /** @var string[] */
+    private $pendingPayloads = [];
+
+    /** @var bool */
+    private $shutdownRegistered = false;
+
     public function __construct(
         Config $config,
         CurlFactory $curlFactory,
@@ -80,41 +86,94 @@ class Report
         );
     }
 
+    private function buildPayload(RequestInterface $request, array $rules): string
+    {
+        return $this->serializer->serialize([
+            'type' => 'report',
+            'timestamp' => time(),
+            'rules' => $rules,
+            'version' => $this->getPackageVersion(),
+            'product_version' => $this->getProductVersion(),
+            'request' => [
+                'method'  => $request->getMethod(),
+                'uri'     => $request->getRequestUri(),
+                'body'    => $request->getContent(),
+                'ips'     => $this->ip->collectRequestIPs(),
+                'headers' => $this->getRequestHeaders($request),
+                'scheme'  => $request->getScheme(),
+                'params'  => $request->getParams(),
+                'files'   => $request->getFiles(),
+            ]
+        ]);
+    }
+
+    private function postPayload(string $data)
+    {
+        $curl = $this->curlFactory->create();
+        $curl->setCredentials($this->config->getLicenseKey(), $this->config->getLicenseKey());
+        $curl->setTimeout(5);
+        $curl->addHeader('Expect', ''); // prevents curl from expecting 100-continue
+        $curl->addHeader('Content-Type', 'application/json');
+        $curl->post($this->config->getReportUrl(), $data);
+
+        if (!in_array($curl->getStatus(), [200, 429])) {
+            throw new \RuntimeException(sprintf("Invalid status code: %d", $curl->getStatus()));
+        }
+    }
+
+    private function logFailure(\Exception $e)
+    {
+        $this->logger->error(sprintf("Failed to send report: %s", $e->getMessage()));
+    }
+
     public function sendReport(RequestInterface $request, array $rules)
     {
         if (!$this->config->isReportEnabled()) {
             return;
         }
         try {
-            $curl = $this->curlFactory->create();
-            $curl->setCredentials($this->config->getLicenseKey(), $this->config->getLicenseKey());
-            $curl->setTimeout(5);
-            $curl->addHeader('Expect', ''); // prevents curl from expecting 100-continue
-            $curl->addHeader('Content-Type', 'application/json');
-            $data = $this->serializer->serialize([
-                'type' => 'report',
-                'timestamp' => time(),
-                'rules' => $rules,
-                'version' => $this->getPackageVersion(),
-                'product_version' => $this->getProductVersion(),
-                'request' => [
-                    'method'  => $request->getMethod(),
-                    'uri'     => $request->getRequestUri(),
-                    'body'    => $request->getContent(),
-                    'ips'     => $this->ip->collectRequestIPs(),
-                    'headers' => $this->getRequestHeaders($request),
-                    'scheme'  => $request->getScheme(),
-                    'params'  => $request->getParams(),
-                    'files'   => $request->getFiles(),
-                ]
-            ]);
-            $curl->post($this->config->getReportUrl(), $data);
-
-            if (!in_array($curl->getStatus(), [200, 429])) {
-                throw new \RuntimeException(sprintf("Invalid status code: %d", $curl->getStatus()));
-            }
+            $this->postPayload($this->buildPayload($request, $rules));
         } catch (\Exception $e) {
-            $this->logger->error(sprintf("Failed to send report: %s", $e->getMessage()));
+            $this->logFailure($e);
+        }
+    }
+
+    public function sendReportDeferred(RequestInterface $request, array $rules)
+    {
+        if (!$this->config->isReportEnabled()) {
+            return;
+        }
+        try {
+            // Built now: at shutdown the request body stream, the config cache and the version cache
+            // backend may already be closed.
+            $this->pendingPayloads[] = $this->buildPayload($request, $rules);
+        } catch (\Exception $e) {
+            $this->logFailure($e);
+            return;
+        }
+        if (!$this->shutdownRegistered) {
+            $this->shutdownRegistered = true;
+            register_shutdown_function([$this, 'flushDeferredReports']);
+        }
+    }
+
+    public function flushDeferredReports()
+    {
+        $payloads = $this->pendingPayloads;
+        $this->pendingPayloads = [];
+        if (empty($payloads)) {
+            return;
+        }
+        // Only PHP-FPM exposes this; on CLI and mod_php the reports are sent as before.
+        if (function_exists('fastcgi_finish_request')) {
+            fastcgi_finish_request();
+        }
+        foreach ($payloads as $payload) {
+            try {
+                $this->postPayload($payload);
+            } catch (\Exception $e) {
+                $this->logFailure($e);
+            }
         }
     }
 

--- a/Model/Report.php
+++ b/Model/Report.php
@@ -5,11 +5,14 @@ namespace Sansec\Shield\Model;
 use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Framework\App\RequestInterface;
 use Magento\Framework\HTTP\Client\CurlFactory;
+use Magento\Framework\MessageQueue\PublisherInterface;
 use Magento\Framework\Serialize\SerializerInterface;
 use Psr\Log\LoggerInterface as Logger;
 
 class Report
 {
+    public const TOPIC_REPORT = 'sansec.shield.report';
+
     /** @var Config  */
     private $config;
 
@@ -37,6 +40,9 @@ class Report
     /** @var bool */
     private $shutdownRegistered = false;
 
+    /** @var PublisherInterface */
+    private $publisher;
+
     public function __construct(
         Config $config,
         CurlFactory $curlFactory,
@@ -44,6 +50,7 @@ class Report
         SerializerInterface $serializer,
         IP $ip,
         ProductMetadataInterface $productMetadata,
+        PublisherInterface $publisher,
         array $filteredHeaders = []
     ) {
         $this->config = $config;
@@ -52,6 +59,7 @@ class Report
         $this->serializer = $serializer;
         $this->ip = $ip;
         $this->productMetadata = $productMetadata;
+        $this->publisher = $publisher;
         $this->filteredHeaders = $filteredHeaders;
     }
 
@@ -154,6 +162,27 @@ class Report
         if (!$this->shutdownRegistered) {
             $this->shutdownRegistered = true;
             register_shutdown_function([$this, 'flushDeferredReports']);
+        }
+    }
+
+    public function publishReport(RequestInterface $request, array $rules)
+    {
+        if (!$this->config->isReportEnabled()) {
+            return;
+        }
+        try {
+            $this->publisher->publish(self::TOPIC_REPORT, $this->buildPayload($request, $rules));
+        } catch (\Exception $e) {
+            $this->logFailure($e);
+        }
+    }
+
+    public function sendPayload(string $payload)
+    {
+        try {
+            $this->postPayload($payload);
+        } catch (\Exception $e) {
+            $this->logFailure($e);
         }
     }
 

--- a/Model/Report/Consumer.php
+++ b/Model/Report/Consumer.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Sansec\Shield\Model\Report;
+
+use Sansec\Shield\Model\Report;
+
+class Consumer
+{
+    /** @var Report */
+    private $report;
+
+    public function __construct(Report $report)
+    {
+        $this->report = $report;
+    }
+
+    public function process(string $payload)
+    {
+        $this->report->sendPayload($payload);
+    }
+}

--- a/Plugin/Shield.php
+++ b/Plugin/Shield.php
@@ -86,7 +86,7 @@ class Shield
             return $proceed($request);
         }
 
-        $this->report->sendReport($request, $matchedRules);
+        $this->report->sendReportDeferred($request, $matchedRules);
 
         foreach ($matchedRules as $rule) {
             if ($rule->action === 'block') {

--- a/Plugin/Shield.php
+++ b/Plugin/Shield.php
@@ -86,7 +86,11 @@ class Shield
             return $proceed($request);
         }
 
-        $this->report->sendReportDeferred($request, $matchedRules);
+        if ($this->config->getReportTransport() === Config::REPORT_TRANSPORT_QUEUE) {
+            $this->report->publishReport($request, $matchedRules);
+        } else {
+            $this->report->sendReportDeferred($request, $matchedRules);
+        }
 
         foreach ($matchedRules as $rule) {
             if ($rule->action === 'block') {

--- a/Test/Model/ReportTest.php
+++ b/Test/Model/ReportTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Sansec\Shield\Test\Model;
+
+use Magento\Framework\App\ProductMetadataInterface;
+use Magento\Framework\HTTP\Client\Curl;
+use Magento\Framework\HTTP\Client\CurlFactory;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface as Logger;
+use Sansec\Shield\Model\Config;
+use Sansec\Shield\Model\IP;
+use Sansec\Shield\Model\Report;
+use Sansec\Shield\Model\Serializer;
+use Sansec\Shield\Test\RequestStub;
+
+class ReportTest extends TestCase
+{
+    /** @var array[] */
+    private $posts = [];
+
+    private function buildReport(bool $reportEnabled = true): Report
+    {
+        $config = $this->createMock(Config::class);
+        $config->method('isReportEnabled')->willReturn($reportEnabled);
+        $config->method('getLicenseKey')->willReturn('key');
+        $config->method('getReportUrl')->willReturn('https://shield.example.com/report');
+
+        $curl = $this->createMock(Curl::class);
+        $curl->method('getStatus')->willReturn(200);
+        $curl->method('post')->willReturnCallback(function ($url, $data) {
+            $this->posts[] = [$url, $data];
+        });
+
+        $curlFactory = $this->getMockBuilder(CurlFactory::class)
+            ->disableOriginalConstructor()
+            ->disableAutoload()
+            ->setMethods(['create'])
+            ->getMock();
+        $curlFactory->method('create')->willReturn($curl);
+
+        return new Report(
+            $config,
+            $curlFactory,
+            $this->createMock(Logger::class),
+            new Serializer(),
+            new IP(),
+            $this->createMock(ProductMetadataInterface::class)
+        );
+    }
+
+    public function testDeferredReportIsNotPostedImmediately()
+    {
+        $report = $this->buildReport();
+        $report->sendReportDeferred(new RequestStub(), []);
+
+        $this->assertSame([], $this->posts);
+
+        $report->flushDeferredReports();
+        $this->assertCount(1, $this->posts);
+    }
+
+    public function testFlushPostsEveryDeferredReport()
+    {
+        $report = $this->buildReport();
+        $report->sendReportDeferred(new RequestStub('', 'POST', '/first'), []);
+        $report->sendReportDeferred(new RequestStub('', 'POST', '/second'), []);
+        $report->flushDeferredReports();
+
+        $this->assertCount(2, $this->posts);
+        $this->assertSame('https://shield.example.com/report', $this->posts[0][0]);
+        $this->assertStringContainsString('"uri":"\/first"', $this->posts[0][1]);
+        $this->assertStringContainsString('"uri":"\/second"', $this->posts[1][1]);
+        $this->assertStringContainsString('"type":"report"', $this->posts[0][1]);
+    }
+
+    public function testFlushIsIdempotent()
+    {
+        $report = $this->buildReport();
+        $report->sendReportDeferred(new RequestStub(), []);
+        $report->flushDeferredReports();
+        $report->flushDeferredReports();
+
+        $this->assertCount(1, $this->posts);
+    }
+
+    public function testNothingIsQueuedWhenReportingDisabled()
+    {
+        $report = $this->buildReport(false);
+        $report->sendReportDeferred(new RequestStub(), []);
+        $report->flushDeferredReports();
+
+        $this->assertSame([], $this->posts);
+    }
+}

--- a/Test/Model/ReportTest.php
+++ b/Test/Model/ReportTest.php
@@ -5,11 +5,13 @@ namespace Sansec\Shield\Test\Model;
 use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Framework\HTTP\Client\Curl;
 use Magento\Framework\HTTP\Client\CurlFactory;
+use Magento\Framework\MessageQueue\PublisherInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface as Logger;
 use Sansec\Shield\Model\Config;
 use Sansec\Shield\Model\IP;
 use Sansec\Shield\Model\Report;
+use Sansec\Shield\Model\Report\Consumer;
 use Sansec\Shield\Model\Serializer;
 use Sansec\Shield\Test\RequestStub;
 
@@ -17,6 +19,12 @@ class ReportTest extends TestCase
 {
     /** @var array[] */
     private $posts = [];
+
+    /** @var array[] */
+    private $published = [];
+
+    /** @var PublisherInterface */
+    private $publisher;
 
     private function buildReport(bool $reportEnabled = true): Report
     {
@@ -38,13 +46,19 @@ class ReportTest extends TestCase
             ->getMock();
         $curlFactory->method('create')->willReturn($curl);
 
+        $this->publisher = $this->createMock(PublisherInterface::class);
+        $this->publisher->method('publish')->willReturnCallback(function ($topic, $data) {
+            $this->published[] = [$topic, $data];
+        });
+
         return new Report(
             $config,
             $curlFactory,
             $this->createMock(Logger::class),
             new Serializer(),
             new IP(),
-            $this->createMock(ProductMetadataInterface::class)
+            $this->createMock(ProductMetadataInterface::class),
+            $this->publisher
         );
     }
 
@@ -90,5 +104,37 @@ class ReportTest extends TestCase
         $report->flushDeferredReports();
 
         $this->assertSame([], $this->posts);
+    }
+
+    public function testPublishReportSendsThePayloadToTheTopicWithoutPosting()
+    {
+        $report = $this->buildReport();
+        $report->publishReport(new RequestStub('', 'POST', '/attack'), []);
+
+        $this->assertSame([], $this->posts);
+        $this->assertCount(1, $this->published);
+        $this->assertSame(Report::TOPIC_REPORT, $this->published[0][0]);
+        $this->assertStringContainsString('"uri":"\\/attack"', $this->published[0][1]);
+        $this->assertStringContainsString('"type":"report"', $this->published[0][1]);
+    }
+
+    public function testNothingIsPublishedWhenReportingDisabled()
+    {
+        $report = $this->buildReport(false);
+        $report->publishReport(new RequestStub(), []);
+
+        $this->assertSame([], $this->published);
+        $this->assertSame([], $this->posts);
+    }
+
+    public function testConsumerPostsThePayloadItReceives()
+    {
+        $report = $this->buildReport();
+        (new Consumer($report))->process('{"type":"report"}');
+
+        $this->assertCount(1, $this->posts);
+        $this->assertSame('https://shield.example.com/report', $this->posts[0][0]);
+        $this->assertSame('{"type":"report"}', $this->posts[0][1]);
+        $this->assertSame([], $this->published);
     }
 }

--- a/Test/Plugin/ShieldTest.php
+++ b/Test/Plugin/ShieldTest.php
@@ -25,13 +25,17 @@ namespace Magento\Framework\View\Element {
 namespace Sansec\Shield\Test\Plugin {
 
     use Magento\Framework\App\FrontControllerInterface;
+    use Magento\Framework\App\Response\Http as HttpResponse;
     use Magento\Framework\App\Response\HttpFactory as HttpResponseFactory;
+    use Magento\Framework\View\Element\Template;
     use Magento\Framework\View\Element\TemplateFactory;
     use PHPUnit\Framework\MockObject\Rule\InvocationOrder;
     use PHPUnit\Framework\TestCase;
+    use Psr\Log\LoggerInterface as Logger;
     use Sansec\Shield\Model\Config;
     use Sansec\Shield\Model\IP;
     use Sansec\Shield\Model\Report;
+    use Sansec\Shield\Model\Rule;
     use Sansec\Shield\Model\Waf;
     use Sansec\Shield\Plugin\Shield;
     use Sansec\Shield\Test\RequestStub;
@@ -51,23 +55,45 @@ namespace Sansec\Shield\Test\Plugin {
             $_SERVER = $this->serverBackup;
         }
 
-        private function buildPlugin(array $whitelistedIps, InvocationOrder $expectedWafCalls): Shield
-        {
+        private function buildPlugin(
+            array $whitelistedIps,
+            InvocationOrder $expectedWafCalls,
+            array $matchedRules = [],
+            ?Report $report = null
+        ): Shield {
             $config = $this->createMock(Config::class);
             $config->method('isEnabled')->willReturn(true);
             $config->method('getWhitelistedIps')->willReturn($whitelistedIps);
 
             $waf = $this->createMock(Waf::class);
-            $waf->expects($expectedWafCalls)->method('matchRequest')->willReturn([]);
+            $waf->expects($expectedWafCalls)->method('matchRequest')->willReturn($matchedRules);
 
             return new Shield(
                 $config,
                 $waf,
-                $this->createMock(Report::class),
+                $report ?: $this->createMock(Report::class),
                 new IP(),
-                $this->createMock(HttpResponseFactory::class),
-                $this->createMock(TemplateFactory::class)
+                $this->buildResponseFactory(),
+                $this->buildTemplateFactory()
             );
+        }
+
+        private function buildResponseFactory(): HttpResponseFactory
+        {
+            $factory = $this->createMock(HttpResponseFactory::class);
+            $factory->method('create')->willReturn($this->createMock(HttpResponse::class));
+            return $factory;
+        }
+
+        private function buildTemplateFactory(): TemplateFactory
+        {
+            $template = $this->createMock(Template::class);
+            $template->method('setTemplate')->willReturnSelf();
+            $template->method('toHtml')->willReturn('');
+
+            $factory = $this->createMock(TemplateFactory::class);
+            $factory->method('create')->willReturn($template);
+            return $factory;
         }
 
         private function dispatch(Shield $plugin): bool
@@ -104,6 +130,36 @@ namespace Sansec\Shield\Test\Plugin {
             $_SERVER['REMOTE_ADDR'] = '203.0.113.42';
             $plugin = $this->buildPlugin([], $this->once());
             $this->dispatch($plugin);
+        }
+
+        public function testMatchedRuleDefersTheReport()
+        {
+            $_SERVER['REMOTE_ADDR'] = '203.0.113.42';
+
+            $rule = new Rule(new IP(), $this->createMock(Logger::class), 'report');
+            $report = $this->createMock(Report::class);
+            $report->expects($this->never())->method('sendReport');
+            $report->expects($this->once())->method('sendReportDeferred')->with(
+                $this->isInstanceOf(RequestStub::class),
+                [$rule]
+            );
+
+            $plugin = $this->buildPlugin([], $this->once(), [$rule], $report);
+            $this->assertTrue($this->dispatch($plugin));
+        }
+
+        public function testBlockingRuleDefersTheReportAndSkipsDispatch()
+        {
+            $_SERVER['REMOTE_ADDR'] = '203.0.113.42';
+
+            $rule = new Rule(new IP(), $this->createMock(Logger::class), 'block');
+            $report = $this->createMock(Report::class);
+            $report->expects($this->never())->method('sendReport');
+            $report->expects($this->once())->method('sendReportDeferred');
+            $report->expects($this->once())->method('logBlockedRequest');
+
+            $plugin = $this->buildPlugin([], $this->once(), [$rule], $report);
+            $this->assertFalse($this->dispatch($plugin));
         }
     }
 }

--- a/Test/Plugin/ShieldTest.php
+++ b/Test/Plugin/ShieldTest.php
@@ -59,11 +59,13 @@ namespace Sansec\Shield\Test\Plugin {
             array $whitelistedIps,
             InvocationOrder $expectedWafCalls,
             array $matchedRules = [],
-            ?Report $report = null
+            ?Report $report = null,
+            string $reportTransport = Config::REPORT_TRANSPORT_DIRECT
         ): Shield {
             $config = $this->createMock(Config::class);
             $config->method('isEnabled')->willReturn(true);
             $config->method('getWhitelistedIps')->willReturn($whitelistedIps);
+            $config->method('getReportTransport')->willReturn($reportTransport);
 
             $waf = $this->createMock(Waf::class);
             $waf->expects($expectedWafCalls)->method('matchRequest')->willReturn($matchedRules);
@@ -160,6 +162,36 @@ namespace Sansec\Shield\Test\Plugin {
 
             $plugin = $this->buildPlugin([], $this->once(), [$rule], $report);
             $this->assertFalse($this->dispatch($plugin));
+        }
+
+        public function testQueueTransportPublishesTheReport()
+        {
+            $_SERVER['REMOTE_ADDR'] = '203.0.113.42';
+
+            $rule = new Rule(new IP(), $this->createMock(Logger::class), 'report');
+            $report = $this->createMock(Report::class);
+            $report->expects($this->never())->method('sendReportDeferred');
+            $report->expects($this->never())->method('sendReport');
+            $report->expects($this->once())->method('publishReport')->with(
+                $this->isInstanceOf(RequestStub::class),
+                [$rule]
+            );
+
+            $plugin = $this->buildPlugin([], $this->once(), [$rule], $report, Config::REPORT_TRANSPORT_QUEUE);
+            $this->assertTrue($this->dispatch($plugin));
+        }
+
+        public function testDirectTransportDefersTheReport()
+        {
+            $_SERVER['REMOTE_ADDR'] = '203.0.113.42';
+
+            $rule = new Rule(new IP(), $this->createMock(Logger::class), 'report');
+            $report = $this->createMock(Report::class);
+            $report->expects($this->never())->method('publishReport');
+            $report->expects($this->once())->method('sendReportDeferred');
+
+            $plugin = $this->buildPlugin([], $this->once(), [$rule], $report, Config::REPORT_TRANSPORT_DIRECT);
+            $this->assertTrue($this->dispatch($plugin));
         }
     }
 }

--- a/Test/RequestStub.php
+++ b/Test/RequestStub.php
@@ -112,4 +112,19 @@ class RequestStub implements RequestInterface
     {
         return $this->post;
     }
+
+    public function getHeaders()
+    {
+        return new \Laminas\Stdlib\Parameters($this->headers);
+    }
+
+    public function getFiles()
+    {
+        return new \Laminas\Stdlib\Parameters([]);
+    }
+
+    public function getScheme()
+    {
+        return 'https';
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
   "require": {
     "php": ">=7.2",
     "magento/framework": "*",
+    "magento/module-message-queue": "*",
     "ext-openssl": "*"
   },
   "require-dev": {

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -20,6 +20,12 @@
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment>When this is enabled, blocked requests are reported to the eComscan dashboard.</comment>
                 </field>
+                <field id="report_transport" translate="label comment" type="select" sortOrder="25" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Report Transport</label>
+                    <source_model>Sansec\Shield\Model\Config\Source\ReportTransport</source_model>
+                    <comment>Direct posts the report from the request itself, after the response has been flushed. Message Queue publishes the report to the sansec.shield.report topic instead; it requires consumers to run (the cron consumers_runner job or a supervisor process) and reports only reach the dashboard once a consumer has processed them.</comment>
+                    <depends><field id="report_enabled">1</field></depends>
+                </field>
                 <field id="whitelisted_ips" translate="label comment" type="textarea" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Whitelisted IP Addresses</label>
                     <comment>One IP address per line. Requests from these IPs bypass Shield checks. Matches the connecting peer only (REMOTE_ADDR); proxy-forwarded headers are intentionally ignored.</comment>

--- a/etc/communication.xml
+++ b/etc/communication.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Communication/etc/communication.xsd">
+    <topic name="sansec.shield.report" request="string" is_synchronous="false">
+        <handler name="sansecShieldReport" type="Sansec\Shield\Model\Report\Consumer" method="process"/>
+    </topic>
+</config>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -9,6 +9,7 @@
 
                 <report_enabled>1</report_enabled>
                 <report_url>https://shield.sansec.io/v1/shield/report</report_url>
+                <report_transport>direct</report_transport>
             </general>
         </sansec_shield>
     </default>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -19,6 +19,7 @@
     <type name="Sansec\Shield\Model\Report">
         <arguments>
             <argument name="serializer" xsi:type="object">Sansec\Shield\Model\Serializer</argument>
+            <argument name="publisher" xsi:type="object">Magento\Framework\MessageQueue\PublisherInterface\Proxy</argument>
             <argument name="filteredHeaders" xsi:type="array">
                 <item name="Cookie" xsi:type="string">Cookie</item>
                 <item name="Set-Cookie" xsi:type="string">Set-Cookie</item>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Sansec_Shield"/>
+    <module name="Sansec_Shield">
+        <sequence>
+            <module name="Magento_MessageQueue"/>
+        </sequence>
+    </module>
 </config>

--- a/etc/queue_consumer.xml
+++ b/etc/queue_consumer.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework-message-queue:etc/consumer.xsd">
+    <consumer name="sansec.shield.report" queue="sansec.shield.report"
+              handler="Sansec\Shield\Model\Report\Consumer::process" maxMessages="1000"/>
+</config>

--- a/etc/queue_publisher.xml
+++ b/etc/queue_publisher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework-message-queue:etc/publisher.xsd">
+    <publisher topic="sansec.shield.report"/>
+</config>

--- a/etc/queue_topology.xml
+++ b/etc/queue_topology.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework-message-queue:etc/topology.xsd">
+    <exchange name="magento">
+        <binding id="sansecShieldReport" topic="sansec.shield.report" destination="sansec.shield.report"/>
+    </exchange>
+</config>


### PR DESCRIPTION
Builds on #46 (deferred report); the first commit here is that PR. Review the second commit for this change.

## Summary

Adds `sansec_shield/general/report_transport` with two values:

* `direct` (default), the current behaviour: the payload is built during dispatch and posted after the response has been flushed.
* `queue`: the payload is published to the `sansec.shield.report` topic; a consumer posts it to the endpoint later.

Nothing changes for an existing installation. The queue path only runs when an operator selects it in Stores > Configuration > Security > Sansec Shield.

## Motivation

The previous change took the report off the client's critical path: the 403 is flushed first and only then does the worker POST to `shield.sansec.io`. That fixed page-load latency, but not worker occupancy. A PHP-FPM worker is still held for the duration of the POST, up to the 5 s timeout, after the response is gone. Under a flood of rule-matching requests, the exact traffic the module exists to catch, the pool still drains, just invisibly: the workers are busy on requests whose clients already left.

With `queue`, the matched request does one publish and returns the worker to the pool:

* on the `db` connection, one `INSERT` into `queue_message` plus the status row, sub-millisecond on a healthy database;
* on `amqp`, one `basic.publish` to RabbitMQ.

The outbound HTTP call moves to a consumer process, where its cost is bounded by the consumer, not by the size of the flood.

## Design

**Config.** `report_transport` defaults to `direct` in `etc/config.xml` and is exposed as a select in `etc/adminhtml/system.xml` (`Model\Config\Source\ReportTransport`, no core source model fits a two-value domain-specific list). `Config::getReportTransport()` falls back to `direct` when the value is missing, so an installation that never saved the field behaves exactly as before.

**Topic.** `etc/communication.xml` declares `sansec.shield.report` with `request="string"` and `is_synchronous="false"`. The message is the already serialised JSON payload, so the consumer needs no data-object interface and the payload format stays whatever `Report::buildPayload()` produces.

**Publish side.** `Report::publishReport()` builds the payload with the same private method the direct path uses and publishes it through `Magento\Framework\MessageQueue\PublisherInterface`. Failures are logged with the same `logFailure()` helper, so a broken queue produces a log line rather than an exception on a customer request.

The publisher is injected as a proxy (`Magento\Framework\MessageQueue\PublisherInterface\Proxy` in `etc/di.xml`, the same technique core uses for interfaces, e.g. `Magento\Store\Model\StoreManagerInterface\Proxy` in `Magento_Catalog`'s `di.xml`): `Report` is a constructor dependency of the front-controller plugin, so it is built on every request that reaches the plugin, and instantiating a real publisher would drag in the publisher config, exchange repository and connection pool on requests that never publish anything. With `transport=direct` the proxy costs one empty object and nothing else; the real publisher is only constructed on the first `publish()` call.

**Consume side.** `Model\Report\Consumer::process(string $payload)` calls `Report::sendPayload()`, a thin public wrapper around the existing private `postPayload()` plus the existing try/catch. The endpoint, credentials, headers and the 5 s timeout are the same code path as `direct`.

**Connection resolution.** `etc/queue_publisher.xml`, `etc/queue_topology.xml` and `etc/queue_consumer.xml` deliberately omit the `connection` attribute. All three XML converters (`MessageQueue\{Publisher,Consumer,Topology}\Config\Xml\Converter`) fall back to `MessageQueue\DefaultValueProvider::getConnection()`, which reads `queue/default_connection` from `env.php`, then falls back to `stomp` or `amqp` when those sections are configured, and to `db` otherwise. A merchant running RabbitMQ gets RabbitMQ without touching the module; a merchant without it gets the MySQL queue. The topology binds to the default `magento` exchange, matching `Magento_AsyncConfig` and `Magento_MediaGalleryRenditions`.

**Running consumers.** Either:

```
bin/magento queue:consumers:start sansec.shield.report
```

under a supervisor, or the standard cron path — `consumers_runner` in `Magento_MessageQueue`'s `crontab.xml` runs `* * * * *` in the `consumers` group and spawns declared consumers. It can be tuned in `env.php` under `cron_consumers_runner` (`cron_run`, `consumers`, `max_messages`). The consumer declares `maxMessages="1000"`, so a spawned process exits after 1000 messages and cron restarts it, which is the usual way to keep a long-running PHP process from leaking.

## Trade-offs

**For the queue transport**

* Worker time per matched request drops from a full round trip (or the 5 s timeout) to a single publish.
* Retry semantics come free. A message whose consumer fails stays in the queue and is retried instead of being logged and dropped.
* Resilient to endpoint outages. With `direct`, reports generated while `shield.sansec.io` is unreachable are lost; queued reports drain once it comes back.
* Decouples an attack flood from outbound network capacity. The publish rate is bounded by the database or broker, not by the report endpoint.

**Against**

* Reports are delayed by the consumer cadence. With the default `consumers_runner` cron that is up to a minute before the process even starts. The dashboard stops being real-time, and instant visibility is a large part of the module's value.
* It requires consumers to actually run. This is a common operational gap and a silent one: if cron is misconfigured or the consumer group is disabled, reports accumulate in `queue_message` with nothing failing loudly.
* Full request payloads — POST bodies, headers, IPs — sit at rest in `queue_message` (MySQL) or in RabbitMQ until consumed, and, with the MySQL queue, until cleanup removes the processed rows. Cleanup is `mysqlmq_clean_messages` in `Magento_MysqlMq`'s `crontab.xml` (`Magento\MysqlMq\Model\Observer::cleanupMessages`, schedule `30 6,15 * * *`), which marks messages for deletion only after `system/mysqlmq/successful_messages_lifetime`, default 10080 minutes = 7 days. So a processed attack payload can stay in the merchant's database for a week. `direct` keeps the same data in memory for milliseconds. That is a real widening of the PII footprint, and it is the main reason this is opt-in.
* A new declared dependency on `Magento_MessageQueue`.
* With the `db` connection, one `INSERT` per matched request lands on the main database. Under a flood that moves load onto the component least able to absorb it, and `queue_message` grows until consumers catch up.
* More moving parts to support: a topic, a topology, a consumer process, and a new failure mode ("reports stopped arriving") whose cause is now two systems away from the module.

## Why opt-in and default off

The two transports fail differently, and neither one is right for every shop. `direct` is simple and immediate, and it loses reports when the endpoint is down. `queue` is durable and cheap per request, and it trades away immediacy and keeps attack payloads on disk.

A shop that gets a handful of matches a day should stay on `direct`: the worker cost is irrelevant and the reports arrive at once. A shop that is being hammered, already runs consumers, and cares more about pool stability than about a minute of dashboard lag should switch. Defaulting to `queue` would silently make every existing installation depend on consumers being alive, and would put request bodies into the database of merchants who never asked for it. Defaulting to `direct` keeps the current behaviour and makes the queue an explicit, documented decision with its cost stated in the field comment.

## Dependencies

`composer.json` gains `magento/module-message-queue`, and `etc/module.xml` sequences after `Magento_MessageQueue`. Both `Magento_MessageQueue` and `Magento_MysqlMq` ship with Magento Open Source, so nothing new is installed: the dependency is declared so module load order is correct and the requirement is visible.

## Testing

PHPUnit with `--fail-on-warning` over the module's `Test` directory: 68 tests green. `xmllint --noout` over `etc/**/*.xml`, plus XSD validation of every new file against the framework schemas (`Communication/etc/communication.xsd`, `MessageQueue/etc/publisher.xsd`, `topology.xsd`, `consumer.xsd`) and of the changed `etc/config.xml`, `etc/module.xml` and `etc/adminhtml/system.xml` against their core schemas: all validate.

Coverage:

* `Test/Model/ReportTest.php` — `publishReport()` publishes exactly one message, to `Report::TOPIC_REPORT`, carrying the same serialised payload the direct path would have posted, and posts nothing; nothing is published when `report_enabled` is off; `Consumer::process()` posts the payload it receives, unchanged, to the configured URL.
* `Test/Plugin/ShieldTest.php` — with `report_transport` set to `queue` the plugin calls `publishReport()` and never `sendReportDeferred()`; with `direct` it does the opposite. `buildPlugin()` takes the transport as a parameter and stubs `Config::getReportTransport()`.

Manual scenario:

1. Switch the transport and clear config cache:

   ```
   bin/magento config:set sansec_shield/general/report_transport queue
   bin/magento config:set sansec_shield/general/report_enabled 1
   bin/magento cache:flush
   ```

2. Trigger the built-in test rule:

   ```
   curl -s -o /dev/null -w 'status=%{http_code} total=%{time_total}\n' \
     'https://example.test/?SANSEC-SHIELD-TEST'
   ```

   The 403 comes back and the worker is free immediately: no outbound call happened during the request.

3. Confirm the message landed (MySQL queue):

   ```sql
   SELECT topic_name, COUNT(*) FROM queue_message GROUP BY topic_name;
   ```

   `sansec.shield.report` should show one row per matched request.

4. Drain it by hand:

   ```
   bin/magento queue:consumers:start sansec.shield.report --max-messages=10
   ```

5. The attack appears in the dashboard, and any delivery failure is recorded in `var/log/sansec_shield.log` through the same logger as the direct transport. Repeat step 3 to see the row consumed.

6. Set the transport back to `direct` and confirm reports go out during the request again, with an empty `queue_message`.

